### PR TITLE
Use polling inside docker container

### DIFF
--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -214,6 +214,7 @@ ${dim("elm-live:")}
   const watcher = chokidar.watch("**/*.elm", {
     ignoreInitial: true,
     followSymlinks: false,
+    usePolling: fs.existsSync("/.dockerenv"),
     ignored: "elm-stuff/generated-code/*"
   });
 


### PR DESCRIPTION
Without polling, chokidar won't detect any file change from a mounted volume.
See similar [nodemon caveat][1].

Relying upon the `/.dockerenv` file existence to detect whether we are running
inside a Docker container seems to be a reliable way to do so, since this is
what Docker's libnetwork [is currently doing][2].

[1]: https://github.com/remy/nodemon#application-isnt-restarting
[2]: https://github.com/docker/libnetwork/blob/19ac3ea7f52bb46e0eb10669756cdae0c441a5b1/drivers/bridge/setup_bridgenetfiltering.go#L160-L163