### PR TITLE
Run `elm make` instead of `elm-make` for 0.19 compatibility

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ npm install --global elm elm-live
 npm install --save-dev elm elm-live
 ```
 
-If you’d rather bring your own global `elm-make`, `npm install --global elm-live` will do.
+If you’d rather bring your own global `elm make`, `npm install --global elm-live` will do.
 
 Note that you need *node 6.0+* to run the tool natively. But if you’re stuck on an older version, don’t worry! [Rumour has it](https://github.com/tomekwi/elm-live/issues/2#issuecomment-156698732) that you can transpile the code to ES5!
 
@@ -59,7 +59,7 @@ Note that you need *node 6.0+* to run the tool natively. But if you’re stuck o
 ## SYNOPSIS
 
 ```sh
-elm-live [...<options>] [--] ...<elm-make args>  
+elm-live [...<options>] [--] ...<elm make args>
 elm-live --help
 ```
 
@@ -70,7 +70,7 @@ elm-live --help
 
 ## DESCRIPTION
 
-First, we spawn `elm-make` with the `elm-make args` you’ve given.
+First, we spawn `elm make` with the `elm make args` you’ve given.
 
 When the build is ready, we start a static HTTP server in the current directory. We inject a _live reload_ snippet into every HTML file we serve. Every time a static file has changed, we’ll reload your app in all browsers you’ve opened it with. (Mobile and IE included!)
 
@@ -87,7 +87,7 @@ We also watch all `*.elm` files in the current directory and its subdirectories.
 Set the port to start the server at. If the port is taken, we’ll use the next available one. `PORT` should be a valid port number. Default: `8000`.
 
 #### `--path-to-elm-make=PATH`
-An absolute or relative path to `elm-make`. If you’ve installed _elm-platform_ locally with _npm_ (`npm install --save-dev elm`), you’ll likely want to set this to `node_modules/.bin/elm-make`. Default: `elm-make`.
+An absolute or relative path to `elm make`. If you’ve installed _elm-platform_ locally with _npm_ (`npm install --save-dev elm`), you’ll likely want to set this to `node_modules/.bin/elm make`. Default: `elm make`.
 
 #### `--host=HOSTNAME|IP`
 Set the host interface to attach the server to. Default: `localhost`.
@@ -99,7 +99,7 @@ The base for static content. Default: `.`.
 We’ll open the app in your default browser as soon as the server is up.
 
 #### `--no-recover`
-When _elm-make_ encounters a compile error, we keep _elm-live_ running and give you time to fix your code. Pass `--no-recover` if you want the server to exit immediately whenever it encounters a compile error.
+When _elm make_ encounters a compile error, we keep _elm-live_ running and give you time to fix your code. Pass `--no-recover` if you want the server to exit immediately whenever it encounters a compile error.
 
 #### `--pushstate`
 Serve `index.html` on 404 errors. This lets us use client-side routing in Elm. For instance, we can have a URL like `http://localhost:8000/account` get handled by the Elm _navigation_ package instead of failing with a 404 error.
@@ -110,7 +110,7 @@ Run `EXECUTABLE` before every rebuild. This way you can easily use other tools l
 Heads up! At the moment, we only allow running a single executable without parameters. If you need more than that, please give us a shout at https://git.io/elm-live.before-build-args.
 
 #### `--after-build=EXECUTABLE`
-Just like `--before-build`, but runs after `elm-make`.
+Just like `--before-build`, but runs after `elm make`.
 
 #### `--help`
 You’re looking at it.

--- a/source/elm-live.js
+++ b/source/elm-live.js
@@ -134,7 +134,7 @@ ${dim("elm-live:")}
       outputStream.write(
         `
 ${dim("elm-live:")}
-  Error while calling ${bold("elm-make")}! This output may be helpful:
+  Error while calling ${bold("elm make")}! This output may be helpful:
 
 ${indent(String(elmMake.error), 2)}
 
@@ -146,7 +146,7 @@ ${indent(String(elmMake.error), 2)}
       outputStream.write(
         `
 ${dim("elm-live:")}
-  ${bold("elm-make")} failed! You can find more info above. Keep calm
+  ${bold("elm make")} failed! You can find more info above. Keep calm
   and take your time to fix your code. We’ll try to compile it again
   as soon as you change a file.
 

--- a/source/parse-args.js
+++ b/source/parse-args.js
@@ -3,7 +3,7 @@ const defaults = {
   open: false,
   help: false,
   recover: true,
-  pathToElmMake: "elm-make",
+  pathToElmMake: "elm make",
   host: "localhost",
   dir: ".",
   pushstate: false,

--- a/test.js
+++ b/test.js
@@ -169,19 +169,19 @@ test("Prints the `--version`", assert =>
     assert.is(exitCode, 0, "succeeds");
   }));
 
-test("Shouts if `elm-make` can’t be found", assert =>
+test("Shouts if `elm make` can’t be found", assert =>
   new Promise(resolve => {
     assert.plan(3);
 
     const expectedMessage = new RegExp(
       `^
 elm-live:
-  I can’t find the command elm-make!`
+  I can’t find the command elm make!`
     );
 
     const crossSpawn = {
       sync: command => {
-        assert.is(command, "elm-make", "spawns `elm-make`");
+        assert.is(command, "elm make", "spawns `elm make`");
 
         return { error: { code: "ENOENT" } };
       }
@@ -212,7 +212,7 @@ test("Exits if `--no-recover`", assert => {
 
   const crossSpawn = {
     sync: command => {
-      assert.is(command, "elm-make", "spawns `elm-make`");
+      assert.is(command, "elm make", "spawns `elm make`");
 
       return { status };
     }
@@ -230,7 +230,7 @@ test("Exits if `--no-recover`", assert => {
   assert.is(
     elmLive(["--no-recover"], dummyConfig),
     status,
-    "exits with the same status as `elm-make`"
+    "exits with the same status as `elm make`"
   );
 
   assert.is(elmLive([], dummyConfig), null, "keeps running otherwise");
@@ -245,7 +245,7 @@ test("Informs of compile errors", assert =>
 
     const crossSpawn = {
       sync: (command, _, options) => {
-        assert.is(command, "elm-make", "spawns `elm-make`");
+        assert.is(command, "elm make", "spawns `elm make`");
 
         options.stdio[1].write(message);
 
@@ -257,7 +257,7 @@ test("Informs of compile errors", assert =>
 
     let run = 0;
     const outputStream = qs(chunk => {
-      if (run === 0) assert.is(chunk, message, "prints elm-make output first");
+      if (run === 0) assert.is(chunk, message, "prints elm make output first");
 
       if (run === 1)
         resolve(
@@ -265,7 +265,7 @@ test("Informs of compile errors", assert =>
             naked(chunk),
             `
 elm-live:
-  elm-make failed! You can find more info above. Keep calm
+  elm make failed! You can find more info above. Keep calm
   and take your time to fix your code. We’ll try to compile it again
   as soon as you change a file.
 
@@ -280,7 +280,7 @@ elm-live:
     elmLive([], { outputStream, inputStream: devnull() });
   }));
 
-test("Prints any other `elm-make` error", assert =>
+test("Prints any other `elm make` error", assert =>
   new Promise(resolve => {
     assert.plan(3);
 
@@ -289,7 +289,7 @@ test("Prints any other `elm-make` error", assert =>
 
     const crossSpawn = {
       sync: command => {
-        assert.is(command, "elm-make", "spawns `elm-make`");
+        assert.is(command, "elm make", "spawns `elm make`");
 
         return { status, error: { toString: () => message } };
       }
@@ -303,7 +303,7 @@ test("Prints any other `elm-make` error", assert =>
           naked(chunk),
           `
 elm-live:
-  Error while calling elm-make! This output may be helpful:
+  Error while calling elm make! This output may be helpful:
 
   ${message}
 
@@ -316,10 +316,10 @@ elm-live:
       inputStream: devnull()
     });
 
-    assert.is(exitCode, status, "exits with whatever code `elm-make` returned");
+    assert.is(exitCode, status, "exits with whatever code `elm make` returned");
   }));
 
-test("Passes correct args to `elm-make`", assert => {
+test("Passes correct args to `elm make`", assert => {
   assert.plan(2);
 
   const elmLiveArgs = ["--port=77", "--no-recover"];
@@ -333,7 +333,7 @@ test("Passes correct args to `elm-make`", assert => {
 
   const crossSpawn = {
     sync: (command, args) => {
-      assert.is(command, "elm-make", "spawns `elm-make`");
+      assert.is(command, "elm make", "spawns `elm make`");
 
       assert.deepEqual(args, otherArgs, "passes all not understood arguments");
 
@@ -346,7 +346,7 @@ test("Passes correct args to `elm-make`", assert => {
   elmLive(elmLiveArgs.concat(otherArgs), dummyConfig);
 });
 
-test("Disambiguates `elm-make` args with `--`", assert => {
+test("Disambiguates `elm make` args with `--`", assert => {
   assert.plan(2);
 
   const elmMakeBefore = ["--anything", "whatever", "whatever 2"];
@@ -356,13 +356,13 @@ test("Disambiguates `elm-make` args with `--`", assert => {
 
   const crossSpawn = {
     sync: (command, args) => {
-      assert.is(command, "elm-make", "spawns `elm-make`");
+      assert.is(command, "elm make", "spawns `elm make`");
 
       assert.deepEqual(
         args,
         elmMakeBefore.concat(elmMakeAfter),
         "passes all not understood commands and all commands after the `--` " +
-          "to elm-make"
+          "to elm make"
       );
 
       // Kill after one attempt
@@ -374,7 +374,7 @@ test("Disambiguates `elm-make` args with `--`", assert => {
   elmLive(allArgs, dummyConfig);
 });
 
-test("Spawns `--path-to-elm-make` instead of `elm-make` if given", assert => {
+test("Spawns `--path-to-elm make` instead of `elm make` if given", assert => {
   assert.plan(1);
 
   const pathToElmMake = "/path/to/any/binary";
@@ -392,7 +392,7 @@ test("Spawns `--path-to-elm-make` instead of `elm-make` if given", assert => {
   elmLive([`--path-to-elm-make=${pathToElmMake}`], dummyConfig);
 });
 
-test("Redirects elm-make stdio", assert =>
+test("Redirects elm make stdio", assert =>
   new Promise(resolve => {
     assert.plan(4);
 
@@ -406,7 +406,7 @@ How’s it going?
 
     const crossSpawn = {
       sync: (command, _, options) => {
-        assert.is(command, "elm-make", "spawns `elm-make`");
+        assert.is(command, "elm make", "spawns `elm make`");
 
         assert.is(
           options.stdio[0],
@@ -635,7 +635,7 @@ test("Watches all `**/*.elm` files in the current directory", assert =>
     const failure = { status: 77, error: {} };
     const crossSpawn = {
       sync: command => {
-        if (command !== "elm-make") return success;
+        if (command !== "elm make") return success;
         elmMakeRun++;
 
         if (elmMakeRun === 1) return failure;
@@ -646,7 +646,7 @@ test("Watches all `**/*.elm` files in the current directory", assert =>
         );
 
         assert.pass(
-          "retries spawning `elm-make` if things go wrong the first time"
+          "retries spawning `elm make` if things go wrong the first time"
         );
 
         return success;
@@ -704,8 +704,8 @@ test("--before-build and --after-build work", assert =>
 
     assert.deepEqual(
       commandsRun,
-      [beforeCommand, "elm-make", afterCommand],
-      "Calls the `--before-build` executable, `elm-make` " +
+      [beforeCommand, "elm make", afterCommand],
+      "Calls the `--before-build` executable, `elm make` " +
         "and the `--after-build` executable"
     );
 


### PR DESCRIPTION
I know you're looking for maintainers, but I ran into this when trying out the workshop on 0.19 and figured I'd try making a PR for it anyway! 😄